### PR TITLE
Fix: Missing Sentry auth token on build

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "scripts": {
-    "build": "nest build && npm run sentry:sourcemaps",
+    "build": "nest build",
     "start": "nest start",
     "start:prod": "NODE_ENV=production node dist/src/main",
     "start:dev": "nest start --watch",
@@ -16,8 +16,7 @@
     "migration:up": "mikro-orm migration:up",
     "migration:down": "mikro-orm migration:down",
     "seeder:create": "mikro-orm seeder:create",
-    "seeder:run": "mikro-orm seeder:run",
-    "sentry:sourcemaps": "sentry-cli sourcemaps inject --org liam-truong --project schedly-demo-01 dist && sentry-cli sourcemaps upload --org liam-truong --project schedly-demo-01 dist"
+    "seeder:run": "mikro-orm seeder:run"
   },
   "dependencies": {
     "@mikro-orm/core": "^6.4.16",


### PR DESCRIPTION
## Task:

- Fix  missing Sentry auth token on build

## Description:

- Sentry auth token is missing


## Screenshots:
<img width="1083" height="910" alt="image" src="https://github.com/user-attachments/assets/28c81fac-8bc5-4aac-a8bb-56304eb39c53" />

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
